### PR TITLE
fix sizing issue on about page images

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,8 +19,8 @@
 </nav>
 
 <main class="about-section">
-    <div class="sfu-logo">
-        <img src="SFUlogo.png" alt="Simon Fraser University logo with white text on a red background">
+    <div class="about-block">
+        <img src="SFUlogo.png" alt="Simon Fraser University logo with white text on a red background" class="about-img sfu-logo">
         <p>
         As a motivated third year computer science student at Simon Fraser University, with a background in coding, I am interested in introductory developer roles to grow my technical skills. 
         </p>

--- a/styles.css
+++ b/styles.css
@@ -144,23 +144,23 @@
 }
 
 /* Images next to paragraphs */
-.about-block img {
+.about-block img:not(.sfu-logo) {
   width: 100px;
   height: 100px;
   object-fit: cover;
-  border-radius: 12px; /* Rounded corners */
+  border-radius: 12px;
   flex-shrink: 0;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3); /* Subtle depth */
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
 }
-  
-/* Seperate for sfu logo to ensure it meets SFU guidlines*/
-  .sfu-logo {
-    width: auto;
-    height: 100px;  /* Keep consistent height with other images */
-    object-fit: contain;
-    border-radius: 0;
-    box-shadow: none;
-  }
-  
- 
+
+/* Ensure the SFU logo is not modified and compliant with SFU guidlines */
+.sfu-logo {
+  width: auto;
+  height: auto;
+  max-width: 100px;
+  max-height: 60px;
+  object-fit: contain;
+  border-radius: 0;
+  box-shadow: none;
+}
  


### PR DESCRIPTION
fix sizing issue by modifying SFU logo div class and general image class, and changes to css